### PR TITLE
Fix java.util.ConcurrentModificationException

### DIFF
--- a/src/main/java/com/taykey/twitterlocationparser/DefaultLocationParser.java
+++ b/src/main/java/com/taykey/twitterlocationparser/DefaultLocationParser.java
@@ -19,24 +19,24 @@ public class DefaultLocationParser implements LocationParser {
 
     private LocationDao locationDao;
 
-    private PopulateDB populateDB;
-
     public DefaultLocationParser() {
         locationDao = new MemLocationDao();
-        PopulateDB populateDB = new DefaultPopulateDB(locationDao);
+        final PopulateDB populateDB = new DefaultPopulateDB(locationDao);
         populateDB.loadLocations();
+
+        final Comparator<Location> typeComparator = new Comparator<Location>() {
+            @Override
+            public int compare(Location o1, Location o2) {
+                return o1.getType().compareTo(o2.getType());
+            }
+        };
+
+        locationDao.sortLocationsBy(typeComparator);
     }
 
     public DefaultLocationParser(LocationDao locationDao) {
         this.setLocationDao(locationDao);
     }
-
-    private Comparator<Location> typeComparator = new Comparator<Location>() {
-        @Override
-        public int compare(Location o1, Location o2) {
-            return o1.getType().compareTo(o2.getType());
-        }
-    };
 
     @Override
     public Location parseText(String text) {
@@ -56,7 +56,6 @@ public class DefaultLocationParser implements LocationParser {
                 continue;
             }
 
-            Collections.sort(locations, typeComparator);
             boolean hasTheWordBeenUsedAsCityName = false;
             for (Location location : locations) {
                 if (location.getType() == LocationType.City) {
@@ -230,14 +229,6 @@ public class DefaultLocationParser implements LocationParser {
 
     public void setLocationDao(LocationDao locationDao) {
         this.locationDao = locationDao;
-    }
-
-    public PopulateDB getPopulateDB() {
-        return populateDB;
-    }
-
-    public void setPopulateDB(PopulateDB populateDB) {
-        this.populateDB = populateDB;
     }
 
     private static class Suspect {

--- a/src/main/java/com/taykey/twitterlocationparser/dao/LocationDao.java
+++ b/src/main/java/com/taykey/twitterlocationparser/dao/LocationDao.java
@@ -1,5 +1,6 @@
 package com.taykey.twitterlocationparser.dao;
 
+import java.util.Comparator;
 import java.util.List;
 
 import com.taykey.twitterlocationparser.dto.Location;
@@ -14,4 +15,5 @@ public interface LocationDao {
 
     Location getStateByCode(String stateCode);
 
+    void sortLocationsBy(Comparator<Location> comparator);
 }

--- a/src/main/java/com/taykey/twitterlocationparser/dao/MemLocationDao.java
+++ b/src/main/java/com/taykey/twitterlocationparser/dao/MemLocationDao.java
@@ -1,20 +1,17 @@
 package com.taykey.twitterlocationparser.dao;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import com.taykey.twitterlocationparser.dto.Location;
 import com.taykey.twitterlocationparser.dto.LocationType;
 
 public class MemLocationDao implements LocationDao {
 
-    Map<String, List<Location>> locations = new HashMap<String, List<Location>>();
+    private Map<String, List<Location>> locations = new HashMap<String, List<Location>>();
 
-    Map<String, Location> countries = new HashMap<String, Location>();
+    private Map<String, Location> countries = new HashMap<String, Location>();
 
-    Map<String, Location> states = new HashMap<String, Location>();
+    private Map<String, Location> states = new HashMap<String, Location>();
 
     public MemLocationDao() {
     }
@@ -60,5 +57,11 @@ public class MemLocationDao implements LocationDao {
     @Override
     public Location getStateByCode(String stateCode) {
         return states.get(stateCode);
+    }
+
+    @Override
+    public void sortLocationsBy(final Comparator<Location> comparator) {
+        for (Map.Entry<String, List<Location>> location: locations.entrySet())
+            Collections.sort(location.getValue(), comparator);
     }
 }

--- a/src/main/java/com/taykey/twitterlocationparser/populatedb/DefaultPopulateDB.java
+++ b/src/main/java/com/taykey/twitterlocationparser/populatedb/DefaultPopulateDB.java
@@ -21,9 +21,8 @@ public class DefaultPopulateDB implements PopulateDB {
     private List<String> dataFiles;
 
     public DefaultPopulateDB(LocationDao locationDao) {
-        this.locationDao = locationDao;
-        this.dataFiles = Arrays.asList("data/countries.tsv", "data/states.tsv",
-                "data/cities.tsv");
+        this(locationDao, Arrays.asList("data/countries.tsv", "data/states.tsv",
+              "data/cities.tsv"));
     }
 
     public DefaultPopulateDB(LocationDao locationDao, List<String> dataFiles) {
@@ -32,7 +31,7 @@ public class DefaultPopulateDB implements PopulateDB {
     }
 
     public void loadLocations(String dataFile) {
-        log.debug("start loaading file: {}", dataFile);
+        log.debug("start loading file: {}", dataFile);
         int counter = 0;
         IterableFile iterator = new IterableFile(dataFile);
         for (String text : iterator) {
@@ -42,7 +41,7 @@ public class DefaultPopulateDB implements PopulateDB {
                     fields[2], fields[3], LocationType.valueOf(fields[4]),
                     Integer.parseInt(fields[5])));
         }
-        log.debug("done loaading file: {}. added {} new records", dataFile,
+        log.debug("done loading file: {}. added {} new records", dataFile,
                 counter);
     }
 


### PR DESCRIPTION
Such exception can happen as the list of locations extracted for each word is sorted locally. If we request a list of locations for the same word in parallel, sorting of the same list happens twice and we get such exception.

To prevent this exception and ensure correct performances, the list of locations is sorted at the end of data files loading.
